### PR TITLE
Fix typo causing error when incorrect param entered.

### DIFF
--- a/software/models_interface/hprModel_GUI_frame.py
+++ b/software/models_interface/hprModel_GUI_frame.py
@@ -200,7 +200,7 @@ class HprModel_frame:
 
 			hprModel_function.main(inputFile, window, M, N, t, minSineDur, nH, minf0, maxf0, f0et, harmDevSlope)
 
-		except ValueError as errorMesage:
+		except ValueError as errorMessage:
 			tkMessageBox.showerror("Input values error", errorMessage)
 
 	def play_out_sound(self, extension):


### PR DESCRIPTION
When entering an incorrect N value in the HPR model tab (i.e. not a power of two), the code fails because the exception has been declared with a typo:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1489, in __call__
    return self.func(*args)
  File "/home/sebastien/dev/sms-tools/software/models_interface/hprModel_GUI_frame.py", line 204, in compute_model
    tkMessageBox.showerror("Input values error", errorMessage)
NameError: global name 'errorMessage' is not defined
```
