### PR TITLE
ui: Stop blocking on plt.show()

### DIFF
--- a/software/models_interface/dftModel_function.py
+++ b/software/models_interface/dftModel_function.py
@@ -71,7 +71,7 @@ def main(inputFile = '../../sounds/piano.wav', window = 'blackman', M = 511, N =
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	main()

--- a/software/models_interface/harmonicModel_function.py
+++ b/software/models_interface/harmonicModel_function.py
@@ -79,7 +79,7 @@ def main(inputFile='../../sounds/vignesh.wav', window='blackman', M=1201, N=2048
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	main()

--- a/software/models_interface/hprModel_function.py
+++ b/software/models_interface/hprModel_function.py
@@ -97,7 +97,7 @@ def main(inputFile='../../sounds/sax-phrase-short.wav', window='blackman', M=601
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	main()

--- a/software/models_interface/hpsModel_function.py
+++ b/software/models_interface/hpsModel_function.py
@@ -93,7 +93,7 @@ def main(inputFile='../../sounds/sax-phrase-short.wav', window='blackman', M=601
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	main()

--- a/software/models_interface/sineModel_function.py
+++ b/software/models_interface/sineModel_function.py
@@ -78,7 +78,7 @@ def main(inputFile='../../sounds/bendir.wav', window='hamming', M=2001, N=2048, 
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 
 if __name__ == "__main__":

--- a/software/models_interface/sprModel_function.py
+++ b/software/models_interface/sprModel_function.py
@@ -95,7 +95,7 @@ def main(inputFile='../../sounds/bendir.wav', window='hamming', M=2001, N=2048, 
 
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	main()

--- a/software/models_interface/spsModel_function.py
+++ b/software/models_interface/spsModel_function.py
@@ -92,7 +92,7 @@ def main(inputFile='../../sounds/bendir.wav', window='hamming', M=2001, N=2048, 
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	main()

--- a/software/models_interface/stft_function.py
+++ b/software/models_interface/stft_function.py
@@ -81,7 +81,7 @@ def main(inputFile = '../../sounds/piano.wav', window = 'hamming', M = 1024, N =
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 	
 
 if __name__ == "__main__":

--- a/software/models_interface/stochasticModel_function.py
+++ b/software/models_interface/stochasticModel_function.py
@@ -59,7 +59,7 @@ def main(inputFile='../../sounds/ocean.wav', H=256, N=512, stocf=.1):
 	plt.xlabel('time (sec)')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
   
 if __name__ == "__main__":
 	main()

--- a/software/transformations_interface/harmonicTransformations_function.py
+++ b/software/transformations_interface/harmonicTransformations_function.py
@@ -153,7 +153,7 @@ def transformation_synthesis(inputFile, fs, hfreq, hmag, freqScaling = np.array(
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	
@@ -163,7 +163,7 @@ if __name__ == "__main__":
 	# transformation and synthesis
 	transformation_synthesis (inputFile, fs, hfreq, hmag)
 	
-	plt.show()
+	plt.show(block=False)
 
 
 

--- a/software/transformations_interface/hpsMorph_function.py
+++ b/software/transformations_interface/hpsMorph_function.py
@@ -168,7 +168,7 @@ def transformation_synthesis(inputFile1, fs, hfreq1, hmag1, stocEnv1, inputFile2
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 	
 
 if __name__ == "__main__":
@@ -178,4 +178,4 @@ if __name__ == "__main__":
 	# transformation and synthesis
 	transformation_synthesis (inputFile1, fs1, hfreq1, hmag1, stocEnv1, inputFile2, hfreq2, hmag2, stocEnv2)
 
-	plt.show()
+	plt.show(block=False)

--- a/software/transformations_interface/hpsTransformations_function.py
+++ b/software/transformations_interface/hpsTransformations_function.py
@@ -172,7 +172,7 @@ def transformation_synthesis(inputFile, fs, hfreq, hmag, mYst, freqScaling = np.
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	
@@ -182,4 +182,4 @@ if __name__ == "__main__":
 	# transformation and synthesis
 	transformation_synthesis(inputFile, fs, hfreq, hmag, mYst)
 
-	plt.show()
+	plt.show(block=False)

--- a/software/transformations_interface/sineTransformations_function.py
+++ b/software/transformations_interface/sineTransformations_function.py
@@ -145,7 +145,7 @@ def transformation_synthesis(inputFile, fs, tfreq, tmag, freqScaling = np.array(
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == "__main__":
 	
@@ -155,5 +155,5 @@ if __name__ == "__main__":
 	# transformation and synthesis
 	transformation_synthesis (inputFile, fs, tfreq, tmag)
 
-	plt.show()
+	plt.show(block=False)
 

--- a/software/transformations_interface/stftMorph_function.py
+++ b/software/transformations_interface/stftMorph_function.py
@@ -90,7 +90,7 @@ def main(inputFile1='../../sounds/ocean.wav', inputFile2='../../sounds/speech-ma
 	plt.title('output sound: y')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == '__main__':
 	main()

--- a/software/transformations_interface/stochasticTransformations_function.py
+++ b/software/transformations_interface/stochasticTransformations_function.py
@@ -78,7 +78,7 @@ def main (inputFile='../../sounds/rain.wav', stocf=0.1, timeScaling = np.array([
 	plt.xlabel('time (sec)')
 
 	plt.tight_layout()
-	plt.show()
+	plt.show(block=False)
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
After clicking a "Compute" button, the plot gets displayed but (in OSX at least)
the compute button is not clickable again until the plot window closed.  This
makes imposible to display multiple plots at once.

Also, the parent window is not clickable while the plot is being displayed,
making impossible to do certain operations such us playing the synthesized
sounds in the model window.

This patch fixes both problems by changing all the "plt.show()" calls to
"plt.show(block=False)"
