### PR TITLE
Amend .gitignore to ignore all workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.o
 *.py~
 workspace_dev/*
-workspace/*.py*
+workspace/*
 software/models_interface/output_sounds/*.wav
 software/transformations_interface/output_sounds/*.wav


### PR DESCRIPTION
Minor one. The .gitignore in the master branch is only filtering out python files in the workspace; it used to be set to ignore everything in the workspace. This pull request changes the line in .gitignore from `workspace/*.py*` to `workspace/*`