### PR TITLE
sineModelMultiRes not in sineModel.py

### DIFF
--- a/notebooks/E10-3-Multiresolution.ipynb
+++ b/notebooks/E10-3-Multiresolution.ipynb
@@ -105,7 +105,7 @@
     "B = [XX, XX, XX]\n",
     "\n",
     "# no need to change code from here\n",
-    "y = SM.sineModelMultiRes(x, fs, w, N, t, B)\n",
+    "y = sineModelMultiRes(x, fs, w, N, t, B)\n",
     "ipd.display(ipd.Audio(data=y, rate=fs))"
    ]
   },


### PR DESCRIPTION
fixed error: 
`AttributeError: module 'sineModel' has no attribute 'sineModelMultiRes'`
sineModelMultiRes is defined in the notebook