### PR TITLE
allocate yhfreq, yhmag, ystocEnv instead of resizing in the loop

### DIFF
--- a/software/transformations/hpsTransformations.py
+++ b/software/transformations/hpsTransformations.py
@@ -25,15 +25,12 @@ def hpsTimeScale(hfreq, hmag, stocEnv, timeScaling):
 	yhfreq = np.zeros((indexes.shape[0], hfreq.shape[1]))    # allocate space for yhfreq
 	yhmag = np.zeros((indexes.shape[0], hmag.shape[1]))      # allocate space for yhmag
 	ystocEnv = np.zeros((indexes.shape[0], stocEnv.shape[1]))# allocate space for ystocEnv    
-	yhfreq[0,:] = hfreq[int(round(indexes[0])),:]                    # first output frame
-	yhmag[0,:] = hmag[int(round(indexes[0])),:]                      # first output frame
-	ystocEnv[0,:] = stocEnv[int(round(indexes[0])),:]                # first output frame
-	frameCnt=1    
+	frameIdx = 0    
 	for l in indexes[1:]:                                  # iterate over all output frame indexes
 		yhfreq[frameCnt,:] = hfreq[int(round(l)),:]        # get the closest input frame
 		yhmag[frameCnt,:] = hmag[int(round(l)),:]          # get the closest input frame
 		ystocEnv[frameCnt,:] = stocEnv[int(round(l)),:]    # get the closest input frame
-		frameCnt+=1
+		frameIdx += 1
 	return yhfreq, yhmag, ystocEnv
 	
 	

--- a/software/transformations/hpsTransformations.py
+++ b/software/transformations/hpsTransformations.py
@@ -22,13 +22,18 @@ def hpsTimeScale(hfreq, hmag, stocEnv, timeScaling):
 	outFrames = outL*timeScaling[1::2]/maxOutTime          # output time values in frames
 	timeScalingEnv = interp1d(outFrames, inFrames, fill_value=0)    # interpolation function
 	indexes = timeScalingEnv(np.arange(outL))              # generate frame indexes for the output
-	yhfreq = hfreq[int(round(indexes[0])),:]                    # first output frame
-	yhmag = hmag[int(round(indexes[0])),:]                      # first output frame
-	ystocEnv = stocEnv[int(round(indexes[0])),:]                # first output frame
+	yhfreq = np.zeros((indexes.shape[0], hfreq.shape[1]))    # allocate space for yhfreq
+	yhmag = np.zeros((indexes.shape[0], hmag.shape[1]))      # allocate space for yhmag
+	ystocEnv = np.zeros((indexes.shape[0], stocEnv.shape[1]))# allocate space for ystocEnv    
+	yhfreq[0,:] = hfreq[int(round(indexes[0])),:]                    # first output frame
+	yhmag[0,:] = hmag[int(round(indexes[0])),:]                      # first output frame
+	ystocEnv[0,:] = stocEnv[int(round(indexes[0])),:]                # first output frame
+	frameCnt=1    
 	for l in indexes[1:]:                                  # iterate over all output frame indexes
-		yhfreq = np.vstack((yhfreq, hfreq[int(round(l)),:]))      # get the closest input frame
-		yhmag = np.vstack((yhmag, hmag[int(round(l)),:]))         # get the closest input frame
-		ystocEnv = np.vstack((ystocEnv, stocEnv[int(round(l)),:])) # get the closest input frame
+		yhfreq[frameCnt,:] = hfreq[int(round(l)),:]        # get the closest input frame
+		yhmag[frameCnt,:] = hmag[int(round(l)),:]          # get the closest input frame
+		ystocEnv[frameCnt,:] = stocEnv[int(round(l)),:]    # get the closest input frame
+		frameCnt+=1
 	return yhfreq, yhmag, ystocEnv
 	
 	

--- a/software/transformations/hpsTransformations.py
+++ b/software/transformations/hpsTransformations.py
@@ -27,9 +27,9 @@ def hpsTimeScale(hfreq, hmag, stocEnv, timeScaling):
 	ystocEnv = np.zeros((indexes.shape[0], stocEnv.shape[1]))# allocate space for ystocEnv    
 	frameIdx = 0    
 	for l in indexes[1:]:                                  # iterate over all output frame indexes
-		yhfreq[frameCnt,:] = hfreq[int(round(l)),:]        # get the closest input frame
-		yhmag[frameCnt,:] = hmag[int(round(l)),:]          # get the closest input frame
-		ystocEnv[frameCnt,:] = stocEnv[int(round(l)),:]    # get the closest input frame
+		yhfreq[frameIdx,:] = hfreq[int(round(l)),:]        # get the closest input frame
+		yhmag[frameIdx,:] = hmag[int(round(l)),:]          # get the closest input frame
+		ystocEnv[frameIdx,:] = stocEnv[int(round(l)),:]    # get the closest input frame
 		frameIdx += 1
 	return yhfreq, yhmag, ystocEnv
 	


### PR DESCRIPTION
Sped up the function `hpsTimeScale` in hpsTransformations.py by allocating the hps output representation containers before the loop, instead of resizing them in every loop iteration.