### PR TITLE
[Fix] Fixes Issue #145 on MTG/sms-tools

### DIFF
--- a/software/models/harmonicModel.py
+++ b/software/models/harmonicModel.py
@@ -75,7 +75,7 @@ def harmonicDetection(pfreq, pmag, pphase, f0, nH, hfreqp, fs, harmDevSlope=0.01
     hphase = np.zeros(nH)  # initialize harmonic phases
     hf = f0 * np.arange(1, nH + 1)  # initialize harmonic frequencies
     hi = 0  # initialize harmonic index
-    if hfreqp == []:  # if no incomming harmonic tracks initialize to harmonic series
+    if len(hfreqp) == 0:  # if no incomming harmonic tracks initialize to harmonic series
         hfreqp = hf
     while (f0 > 0) and (hi < nH) and (hf[hi] < fs / 2):  # find harmonic peaks
         pei = np.argmin(abs(pfreq - hf[hi]))  # closest peak


### PR DESCRIPTION
`hfreqp` is initialized to a python empty list. It gets reassigned to be a Numpy array in the loop to calculate frame-wise harmonics, and thus the comparison fails to work. Modifying the code as per this PR, makes the comparison work both for empty Python lists and empty Numpy arrays.